### PR TITLE
Update index.css

### DIFF
--- a/static/css/index.css
+++ b/static/css/index.css
@@ -625,7 +625,7 @@ code {
   }
   
   .more-works-container {
-    bottom: 2rem;
+    bottom: 6rem;
     right: 1rem;
     top: auto;
   }
@@ -667,7 +667,7 @@ code {
   
   .more-works-container {
     position: fixed;
-    bottom: 2rem;
+    bottom: 6rem;
     right: 1rem;
     z-index: 1000;
   }


### PR DESCRIPTION
When the screen width is below 768px and 480px, the “More Works” button overlaps with the scroll. To prevent this, we can move the “More Works” button slightly upward.